### PR TITLE
Remove env usage for secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,48 @@
-# Dropbox ⇄ Git Sync Helpers
+# Dropbox ⇄ Git Sync Helpers
 
-These tiny Python scripts keep **one file (or folder)** in your Dropbox
-perfectly in‑sync with a Git repository.
-They create throw‑away branches on pulls,
-refuse to overwrite newer remote data on pushes,
-and store the time of the last successful pull in a tiny log file.
+These tiny Python scripts keep **one file (or folder)** in your Dropbox perfectly in‑sync with a Git repository. They create throw‑away branches on pulls, refuse to overwrite newer remote data on pushes, and store the time of the last successful pull in a log file.
 
 ---
 
-## 1. Prerequisites
+## 1. Prerequisites
 
-* Python ≥ 3.10
-* `pip install dropbox python-dotenv`
-* A Dropbox **“Scoped App”** with _files.content.write_ +
-  _files.content.read_ permissions
-  (Dashboard → “App Console” → Create App → Scoped Access)
+* Python ≥ 3.10
+* `pip install dropbox`
+* [`pass`](https://www.passwordstore.org/) for secret management
+* A Dropbox **“Scoped App”** with *files.content.write* and *files.content.read* permissions
 
 ---
 
-## 2. Getting credentials **once**
+## 2. Storing credentials
+
+All secrets are kept in `pass`. Create the following entries:
 
 ```bash
-# a) set two env vars temporarily …
-export DROPBOX_APP_KEY=…  DROPBOX_APP_SECRET=…
+pass insert services/uni/dropbox.com/appkey
+pass insert services/uni/dropbox.com/appsecret
+pass insert services/uni/dropbox.com/refresh_token
+```
 
-# b) run the helper (prints refresh token):
-python authorize_once.py
+After storing your credentials, run `python authorize_once.py` once to verify everything works.
+
+---
+
+## 3. Configuration
+
+Edit `config.py` to point to your Dropbox file or folder and the local paths. **No secrets** are stored in this file.
+
+---
+
+## 4. Usage
+
+Pull the data from Dropbox:
+
+```bash
+python dropbox_pull.py
+```
+
+Push local changes back:
+
+```bash
+python dropbox_push.py
+```

--- a/authorize_once.py
+++ b/authorize_once.py
@@ -1,11 +1,11 @@
 import dropbox
-import os
 import subprocess
+import config
 
 try:
     ACCESS_TOKEN = subprocess.check_output(
-        ["pass", "show", "services/uni/dropbox.com/apiacesstoken"],
-        text=True
+        ["pass", "show", f"{config.PASS_PREFIX}/apiacesstoken"],
+        text=True,
     ).strip()
 except subprocess.CalledProcessError as e:
     print("❌ Failed to retrieve Dropbox token from pass.")
@@ -13,8 +13,8 @@ except subprocess.CalledProcessError as e:
 
 try:
     APP_KEY = subprocess.check_output(
-        ["pass", "show", "services/uni/dropbox.com/appkey"],
-        text=True
+        ["pass", "show", f"{config.PASS_PREFIX}/appkey"],
+        text=True,
     ).strip()
 except subprocess.CalledProcessError as e:
     print("❌ Failed to retrieve app key from pass.")
@@ -22,8 +22,8 @@ except subprocess.CalledProcessError as e:
 
 try:
     APP_SECRET = subprocess.check_output(
-        ["pass", "show", "services/uni/dropbox.com/appsecret"],
-        text=True
+        ["pass", "show", f"{config.PASS_PREFIX}/appsecret"],
+        text=True,
     ).strip()
 except subprocess.CalledProcessError as e:
     print("❌ Failed to retrieve app secret from pass.")
@@ -32,8 +32,8 @@ except subprocess.CalledProcessError as e:
 
 try:
     ACCESS_CODE = subprocess.check_output(
-        ["pass", "show", "services/uni/dropbox.com/refresh_token"],
-        text=True
+        ["pass", "show", f"{config.PASS_PREFIX}/refresh_token"],
+        text=True,
     ).strip()
 except subprocess.CalledProcessError as e:
     print("❌ Failed to retrieve refresh token from pass.")

--- a/base_functions.py
+++ b/base_functions.py
@@ -5,7 +5,7 @@ Git branch, keeping your main branch immaculate.
 """
 from datetime import datetime, timezone
 from pathlib import Path
-import argparse, subprocess, os
+import argparse, subprocess
 from dropbox_auth import get_dropbox_client
 import config
 

--- a/config.py
+++ b/config.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+# Prefix inside pass where Dropbox secrets are stored
+PASS_PREFIX = "services/uni/dropbox.com"
+
+# Dropbox link and local paths
+DROPBOX_REMOTE_PATH = "/path/in/dropbox"
+LOCAL_FILE_PATH = Path("./local_file")
+TIMESTAMP_LOG_PATH = Path("./.last_sync_time")

--- a/dropbox_auth.py
+++ b/dropbox_auth.py
@@ -21,18 +21,18 @@ def _read_from_pass(field: str) -> str:
         ) from exc
 
 
-def _get_secret(env_name: str, pass_field: str) -> str:
-    """env ▷ pass ▷ error (no silent None‑returns)."""
-    return getattr(config, env_name) or _read_from_pass(pass_field)
+def _get_secret(pass_field: str) -> str:
+    """Return the secret from pass."""
+    return _read_from_pass(pass_field)
 
 
 # ── public API:
 def get_credentials() -> Tuple[str, str, str]:
-    """Fetch (app_key, app_secret, refresh_token) from env / pass."""
+    """Fetch (app_key, app_secret, refresh_token) from pass."""
     return (
-        _get_secret("DROPBOX_APP_KEY", "appkey"),
-        _get_secret("DROPBOX_APP_SECRET", "appsecret"),
-        _get_secret("DROPBOX_REFRESH_TOKEN", "refresh_token"),
+        _get_secret("appkey"),
+        _get_secret("appsecret"),
+        _get_secret("refresh_token"),
     )
 
 

--- a/dropbox_pull.py
+++ b/dropbox_pull.py
@@ -5,7 +5,7 @@ Git branch, keeping your main branch immaculate.
 """
 from datetime import datetime, timezone
 from pathlib import Path
-import argparse, subprocess, os
+import argparse
 from dropbox_auth import get_dropbox_client
 import config
 from base_functions import *

--- a/dropbox_push.py
+++ b/dropbox_push.py
@@ -3,7 +3,7 @@
 Upload LOCAL_FILE_PATH to Dropbox, making sure we never overwrite newer remote content.
 Interactive prompt if remote is newer than our last pull.
 """
-import argparse, os, subprocess
+import argparse
 from datetime import datetime, timezone
 from pathlib import Path
 import dropbox


### PR DESCRIPTION
## Summary
- use `pass` for all Dropbox secrets
- add simple `config.py` for non-secret settings
- document pass-based workflow
- remove unused imports

## Testing
- `python -m py_compile *.py additional_scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_687e35c4f8108331a958033478486f08