### PR TITLE
Fix imports and refresh authorize_once script

### DIFF
--- a/additional_scripts/writetimeonce.py
+++ b/additional_scripts/writetimeonce.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 from datetime import datetime, timezone
 
 TIMESTAMP_LOG = "./.last_sync_time"

--- a/authorize_once.py
+++ b/authorize_once.py
@@ -1,50 +1,44 @@
-"""One-shot helper to exchange an OAuth authorization code for tokens."""
-import dropbox
+"""Interactive helper to obtain a Dropbox refresh token."""
+
+from dropbox.oauth import DropboxOAuth2FlowNoRedirect
 import subprocess
 import config
 
-# Credentials are fetched from the user's password store ('pass').
 
-try:
-    ACCESS_TOKEN = subprocess.check_output(
-        ["pass", "show", f"{config.PASS_PREFIX}/apiacesstoken"],
-        text=True,
-    ).strip()
-except subprocess.CalledProcessError as e:
-    print("❌ Failed to retrieve Dropbox token from pass.")
-    exit(1)
-
-try:
-    APP_KEY = subprocess.check_output(
-        ["pass", "show", f"{config.PASS_PREFIX}/appkey"],
-        text=True,
-    ).strip()
-except subprocess.CalledProcessError as e:
-    print("❌ Failed to retrieve app key from pass.")
-    exit(1)
-
-try:
-    APP_SECRET = subprocess.check_output(
-        ["pass", "show", f"{config.PASS_PREFIX}/appsecret"],
-        text=True,
-    ).strip()
-except subprocess.CalledProcessError as e:
-    print("❌ Failed to retrieve app secret from pass.")
-    exit(1)
+def _read_from_pass(field: str) -> str | None:
+    """Return the secret from ``pass`` if available."""
+    try:
+        return (
+            subprocess.check_output(
+                ["pass", "show", f"{config.PASS_PREFIX}/{field}"],
+                text=True,
+            ).strip()
+        )
+    except subprocess.CalledProcessError:
+        return None
 
 
-try:
-    ACCESS_CODE = subprocess.check_output(
-        ["pass", "show", f"{config.PASS_PREFIX}/refresh_token"],
-        text=True,
-    ).strip()
-except subprocess.CalledProcessError as e:
-    print("❌ Failed to retrieve refresh token from pass.")
-    exit(1)
+def main() -> None:
+    """Start an OAuth flow and print the resulting tokens."""
+    app_key = _read_from_pass("appkey") or input("Dropbox app key: ").strip()
+    app_secret = _read_from_pass("appsecret") or input("Dropbox app secret: ").strip()
 
-flow = dropbox.DropboxOAuth2FlowNoRedirect(APP_KEY, APP_SECRET, token_access_type='offline')
-oauth_result = flow.finish(ACCESS_CODE)
+    flow = DropboxOAuth2FlowNoRedirect(app_key, app_secret, token_access_type="offline")
+    authorize_url = flow.start()
+    print("1. Visit:", authorize_url)
+    print("2. Click 'Allow' and copy the authorization code.")
+    code = input("Paste code here: ").strip()
 
-print("Access Token:", oauth_result.access_token)
-print("Refresh Token:", oauth_result.refresh_token)
-print("User ID:", oauth_result.account_id)
+    try:
+        result = flow.finish(code)
+    except Exception as exc:
+        print(f"\u274c Authorization failed: {exc}")
+        return
+
+    print("Access Token:", result.access_token)
+    print("Refresh Token:", result.refresh_token)
+    print("User ID:", result.account_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/base_functions.py
+++ b/base_functions.py
@@ -3,10 +3,9 @@
 Pull a single file from Dropbox *into* the repo and commit it on a temporary
 Git branch, keeping your main branch immaculate.
 """
-from datetime import datetime, timezone
 from pathlib import Path
-import argparse, subprocess
-from dropbox_auth import get_dropbox_client
+import argparse
+import subprocess
 import config
 
 # ── CLI parsing:

--- a/dropbox_pull.py
+++ b/dropbox_pull.py
@@ -4,12 +4,10 @@ Pull a single file from Dropbox *into* the repo and commit it on a temporary
 Git branch, keeping your main branch immaculate.
 """
 from datetime import datetime, timezone
-from pathlib import Path
-import argparse, subprocess, os, sys
+import sys
 
 from dropbox_auth import get_dropbox_client
-import config
-from base_functions import *
+from base_functions import cli, git
 
 def branch_has_changes_vs(base: str = "main") -> bool:
     """

--- a/dropbox_push.py
+++ b/dropbox_push.py
@@ -3,14 +3,12 @@
 Upload LOCAL_FILE_PATH to Dropbox, making sure we never overwrite newer remote content.
 Interactive prompt if remote is newer than our last pull.
 """
-import argparse
 from datetime import datetime, timezone
 from pathlib import Path
 import dropbox
 from dropbox_auth import get_dropbox_client
 from dropbox_pull import pull  # reuse temp‑branch logic
-import config
-from base_functions import *
+from base_functions import cli
 
 def read_last_pull_time(ts_file: Path):
     """Return the timestamp stored in *ts_file* or ``None`` if the file is absent."""

--- a/writetimeonce.py
+++ b/writetimeonce.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 from datetime import datetime, timezone
 
 TIMESTAMP_LOG = "./.last_sync_time"


### PR DESCRIPTION
## Summary
- update `authorize_once.py` to modern, interactive flow
- clean up unused imports across scripts

## Testing
- `ruff check .`
- `python -m py_compile *.py additional_scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687e4007eee08331a22336337cefdbb9